### PR TITLE
Change WlanReadWpa return type to void

### DIFF
--- a/ESP-sc-gway/ESP-sc-gway.ino
+++ b/ESP-sc-gway/ESP-sc-gway.ino
@@ -418,7 +418,7 @@ void setupTime() {
 // Each line contains an KEY vaue pair describing the gateway configuration
 //
 // ----------------------------------------------------------------------------
-int WlanReadWpa() {
+void WlanReadWpa() {
 	
 	readConfig( CONFIGFILE, &gwayConfig);
 


### PR DESCRIPTION
Arduino core for the ESP32 [sets `-Werror=all`](https://github.com/espressif/arduino-esp32/blob/master/platform.txt#L20-L21) for warning levels of "More" or "All" in the Arduino IDE's **File > Preferences > Compiler warnings** setting. This upgrades what would have previously been a warning about the lack of a return statement in non-void `WlanReadWpa()` to a compilation error. Since the call to `WlanReadWpa()` doesn't expect a return value and there is nothing obvious in the function to return, I have changed the return type to void to fix this error/warning.

Note there is another one of these errors caused by the "ESP8266 and ESP32 Oled Driver for SSD1306 display" library but that issue has already been [resolved upstream](https://github.com/ThingPulse/esp8266-oled-ssd1306/commit/2a3bdf8fe6c8c3ded81faea90ddbed8cdd98a75d) and so the solution there is to simply update the library to 4.0.0.

I recommend you to set **File > Preferences > Compiler warnings: > All**.